### PR TITLE
Fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,6 @@ I build stuff
 
 ### Badges
 
-<b>My GitHub Stats</b>
-
-<a href="http://www.github.com/gwennhester"><img src="https://github-readme-stats.shion.dev/api?username=gwennhester&theme=dark&hide_border=false&include_all_commits=false&count_private=false" alt="gwennhester's GitHub stats" /></a>
-
 <a href="http://www.github.com/gwennhester"><img src="https://github-readme-streak-stats.herokuapp.com/?user=gwennhester&stroke=ffffff&background=1c1917&ring=14b8a6&fire=14b8a6&currStreakNum=ffffff&currStreakLabel=14b8a6&sideNums=ffffff&sideLabels=ffffff&dates=ffffff&hide_border=true" /></a>
 
-<a href="http://www.github.com/gwennhester"><img src="https://github-readme-stats.vercel.app/api?username=gwennhester&show_icons=true&hide=&count_private=true&title_color=14b8a6&text_color=ffffff&icon_color=14b8a6&bg_color=1c1917&hide_border=true&show_icons=true" alt="gwennhester's GitHub stats" /></a>
-
 <a href="https://github.com/gwennhester" align="left"><img src="https://github-readme-stats.shion.dev/api/top-langs/?username=gwennhester&theme=dark&hide_border=false&include_all_commits=false&count_private=false&layout=compact" alt="Top Languages" /></a>
-
-<p><a href="https://github.com/ryo-ma/github-profile-trophy"><img src="https://github-profile-trophy.vercel.app/?username=gwennhester" alt="gwennhester" /></a></p>

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ I build stuff
 
 <b>My GitHub Stats</b>
 
-<a href="http://www.github.com/gwennhester"><img src="https://github-readme-stats.vercel.app/api?username=gwennhester&show_icons=true&hide=&count_private=true&title_color=14b8a6&text_color=ffffff&icon_color=14b8a6&bg_color=1c1917&hide_border=true&show_icons=true" alt="gwennhester's GitHub stats" /></a>
+<a href="http://www.github.com/gwennhester"><img src="https://github-readme-stats.shion.dev/api?username=gwennhester&theme=dark&hide_border=false&include_all_commits=false&count_private=false" alt="gwennhester's GitHub stats" /></a>
 
 <a href="http://www.github.com/gwennhester"><img src="https://github-readme-streak-stats.herokuapp.com/?user=gwennhester&stroke=ffffff&background=1c1917&ring=14b8a6&fire=14b8a6&currStreakNum=ffffff&currStreakLabel=14b8a6&sideNums=ffffff&sideLabels=ffffff&dates=ffffff&hide_border=true" /></a>
 
 <a href="http://www.github.com/gwennhester"><img src="https://github-readme-stats.vercel.app/api?username=gwennhester&show_icons=true&hide=&count_private=true&title_color=14b8a6&text_color=ffffff&icon_color=14b8a6&bg_color=1c1917&hide_border=true&show_icons=true" alt="gwennhester's GitHub stats" /></a>
 
-<a href="https://github.com/gwennhester" align="left"><img src="https://github-readme-stats.vercel.app/api/top-langs/?username=gwennhester&langs_count=10&title_color=14b8a6&text_color=ffffff&icon_color=14b8a6&bg_color=1c1917&hide_border=true&locale=en&custom_title=Top%20%Languages" alt="Top Languages" /></a>
+<a href="https://github.com/gwennhester" align="left"><img src="https://github-readme-stats.shion.dev/api/top-langs/?username=gwennhester&theme=dark&hide_border=false&include_all_commits=false&count_private=false&layout=compact" alt="Top Languages" /></a>
 
 <p><a href="https://github.com/ryo-ma/github-profile-trophy"><img src="https://github-profile-trophy.vercel.app/?username=gwennhester" alt="gwennhester" /></a></p>


### PR DESCRIPTION
## Summary
- Removed unresponsive Vercel widgets (github-readme-stats and github-profile-trophy) that were returning 503 errors
- Kept working streak stats from herokuapp